### PR TITLE
Adding Personal information

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -12350,6 +12350,18 @@
             "emails": ["russellhaering@gmail.com", "russell.haering@rackspace.com"]
         },
         {
+            "launchpad_id": "rustinpeace",
+            "gerrit_id": "Rustinpeace",
+            "companies": [
+                {
+                    "company_name": "UnitedStack",
+                    "end_date": null
+                }
+            ],
+            "user_name": "Rust Shen",
+            "emails": ["jingyuan@unitedstack.com", "rustinpeace@163.com"]
+        },
+        {
             "launchpad_id": "ryan-petrello",
             "gerrit_id": "ryanpetrello",
             "companies": [


### PR DESCRIPTION
For some reason I can't find myself in the default_data.json

I need to add myself first and then change my affiliation information

Since for now my contribution is labeled "*independent"