### PR TITLE
Add Apprenda domain for @apprenda.com email contributors

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -23012,6 +23012,10 @@
         {
             "domains": ["zte.com.cn"],
             "company_name": "ZTE Corporation"
+        },
+        {
+            "domains": ["apprenda.com"],
+            "company_name": "Apprenda"
         }
     ],
     "repos": [


### PR DESCRIPTION
Adding this since current commits by @apprenda.com accounts are classified as *independent