### PR TITLE
add project swarmkit for docker org

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -25069,6 +25069,11 @@
             "uri": "https://github.com/docker/swarm.git"
         },
         {
+            "module": "swarmkit",
+            "organization": "docker",
+            "uri": "https://github.com/docker/swarmkit.git"
+        },
+        {
             "module": "libtrust",
             "organization": "docker",
             "uri": "https://github.com/docker/libtrust.git"
@@ -25919,7 +25924,7 @@
         },
         {
             "module_group_name": "docker-group",
-            "modules": ["docker", "docker-registry", "docker-network", "engine-api", "libcontainer", "distribution", "machine", "swarm", "libtrust",
+            "modules": ["docker", "docker-registry", "docker-network", "engine-api", "libcontainer", "distribution", "machine", "swarm", "swarmkit", "libtrust",
                 "compose", "docker-py", "libnetwork"]
         },
         {


### PR DESCRIPTION
We all know that in container orchestration ecosystem, there are some famous project like swarm, swarmkit, kubernetes, and so on.

And I found that project swarmkit is missing in docker organization.

This PR tries to add it, and will make it more complete.

Thanks a lot.

Signed-off-by: allencloud <allen.sun@daocloud.io>