### PR TITLE
add project libcompose for docker org

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -25387,6 +25387,11 @@
             "organization": "docker",
             "uri": "https://github.com/docker/compose.git"
         },
+	{
+            "module": "libcompose",
+            "organization": "docker",
+            "uri": "https://github.com/docker/libcompose.git"
+        },
         {
             "module": "docker-py",
             "organization": "docker",
@@ -26229,7 +26234,7 @@
         {
             "module_group_name": "docker-group",
             "modules": ["docker", "docker-registry", "docker-network", "engine-api", "libcontainer", "distribution", "machine", "swarm", "swarmkit", "libtrust",
-                "compose", "docker-py", "libnetwork"]
+                "compose", "docker-py", "libnetwork", "libcompose"]
         },
         {
             "module_group_name": "ansible-group",


### PR DESCRIPTION
I think that libcompose is missing in docker org  which is added to make docker org more complete.

Thanks.

Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>