### PR TITLE
add project libcompose for docker org

### DIFF
--- a/etc/default_data.json
+++ b/etc/default_data.json
@@ -25467,6 +25467,11 @@
             "uri": "https://github.com/docker/compose.git"
         },
         {
+            "module": "libcompose",
+            "organization": "docker",
+            "uri": "https://github.com/docker/libcompose.git"
+        },
+        {
             "module": "docker-py",
             "organization": "docker",
             "uri": "https://github.com/docker/docker-py.git"
@@ -26308,7 +26313,7 @@
         {
             "module_group_name": "docker-group",
             "modules": ["docker", "docker-registry", "docker-network", "engine-api", "libcontainer", "distribution", "machine", "swarm", "swarmkit", "libtrust",
-                "compose", "docker-py", "libnetwork", "containerd"]
+                "compose", "docker-py", "libnetwork", "containerd", "libcompose"]
         },
         {
             "module_group_name": "ansible-group",


### PR DESCRIPTION
I found that libcompose is't in  docker org  which is an experimental go library providing Compose-like functionality in docker community. So I suggest than add it to docker org.
Thanks!


Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>